### PR TITLE
fix creation of error

### DIFF
--- a/Classes/BAPromise.m
+++ b/Classes/BAPromise.m
@@ -573,7 +573,8 @@ typedef NS_ENUM(NSInteger, BAPromiseState) {
 
 -(void)reject
 {
-    [self rejectWithError:[[NSError alloc] init]];
+    NSError *error = [NSError errorWithDomain:@"benski.promise.error.domain" code:0 userInfo:@{ NSLocalizedDescriptionKey : @"Promise is rejected" }];
+    [self rejectWithError:error];
 }
 
 -(void)fulfillWithObject:(id)object orRejectWithError:(NSError *)error


### PR DESCRIPTION
From Xcode console:

> [NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:. This message shown only once.