### PR TITLE
Switch to using DispatchWorkItem for cancelation

### DIFF
--- a/BAPromiseTests/CancelTestsSwift.swift
+++ b/BAPromiseTests/CancelTestsSwift.swift
@@ -215,8 +215,10 @@ class CancelTestsSwift: XCTestCase {
         let cancelToken = fulfilledPromise.then({ () -> PromiseResult<Void> in
             return .promise(thenPromise)
         }, queue: DispatchQueue.main)
-        
-        cancelToken.cancel()
+
+        DispatchQueue.main.async {
+            cancelToken.cancel()
+        }
         self.wait(for: [expectation], timeout: 0.5)
     }
 }

--- a/BAPromiseTests/CancelTestsSwift.swift
+++ b/BAPromiseTests/CancelTestsSwift.swift
@@ -49,35 +49,62 @@ class CancelTestsSwift: XCTestCase {
     }
     
     func testCancelTokenAfterFulfillment() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
         let promise = Promise<Void>()
         promise.fulfill(with: .success)
-        promise.cancelled({ XCTFail("Unexpected cancelled callback") }, on: DispatchQueue.main)
-        let token = promise.then({ }, queue: DispatchQueue.main)
-        token.cancel()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        promise.cancelled({
+            XCTFail("Unexpected cancelled callback")
+            expectation.fulfill()
+        }, on: DispatchQueue.main)
+
+        let forFulfillment = XCTestExpectation()
+        let token = promise.then({ forFulfillment.fulfill() }, queue: DispatchQueue.main)
+        self.wait(for: [forFulfillment], timeout: 0.5)
+
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            token.cancel()
+        }
+        self.wait(for: [expectation], timeout: 0.5)
     }
     
     func testCancelPromiseAfterFulfilment() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
         let promise = Promise<Void>()
         promise.fulfill(with: .success)
-        promise.cancelled({ XCTFail("Unexpected cancelled callback") }, on: DispatchQueue.main)
-        promise.cancel()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        promise.cancelled({
+            XCTFail("Unexpected cancelled callback")
+            expectation.fulfill()
+        }, on: DispatchQueue.main)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            promise.cancel()
+        }
+        self.wait(for: [expectation], timeout: 0.5)
     }
     
     func testCancelPromiseAfterRejection() {
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
         let promise = Promise<Void>()
         promise.fulfill(with: .failure(NSError()))
-        promise.cancelled({ XCTFail("Unexpected cancelled callback") }, on: DispatchQueue.main)
-        promise.cancel()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        promise.cancelled({
+            XCTFail("Unexpected cancelled callback")
+expectation.fulfill()
+        }, on: DispatchQueue.main)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            promise.cancel()
+        }
+        self.wait(for: [expectation], timeout: 0.5)
     }
    
     func testLateCancelCallback() {
         let expectation = XCTestExpectation()
         let promise = Promise<Void>()
         promise.cancel()
-        promise.cancelled({ expectation.fulfill() }, on: DispatchQueue.main)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            promise.cancelled({ expectation.fulfill() }, on: DispatchQueue.main)
+        }
         
         self.wait(for: [expectation], timeout: 0.5)
     }

--- a/Classes/Promise.swift
+++ b/Classes/Promise.swift
@@ -222,15 +222,6 @@ public class Promise<ValueType> : PromiseCancelToken {
     }
     
     fileprivate lazy var blocks: Array<PromiseBlock> = []
-
-//    public override func cancelled(_ onCancel: @escaping Canceled, on queue: DispatchQueue) {
-//        PromiseCancelToken.queue.async {
-//            guard let fulfilledObject = self.fulfilledObject, fulfilledObject.resolved else {
-//                super.cancelled(onCancel, on: queue)
-//                return
-//            }
-//        }
-//    }
 }
 
 // MARK: - Completable ( Promise<Void> )

--- a/Classes/Promise.swift
+++ b/Classes/Promise.swift
@@ -8,24 +8,6 @@
 
 import Foundation
 
-internal class AtomicCancel {
-    
-    public var isCanceled: Bool {
-        atomic_thread_fence(memory_order_seq_cst)
-        return underlying == 0 ? false : true
-    }
-    
-    public func cancel() {
-        OSAtomicIncrement32Barrier(&underlying);
-    }
-    
-    public init() {
-        underlying = 0
-    }
-    
-     private var underlying: Int32
-}
-
 public enum PromiseResult<ValueType> {
     case success(ValueType)
     case promise(Promise<ValueType>)
@@ -92,9 +74,6 @@ public class PromiseCancelToken {
     var workItem: DispatchWorkItem? = DispatchWorkItem(block: {}) // we can't inherit so we will use Decorator Pattern instead
     static let queue = DispatchQueue(label: "com.github.benski.promise")
     internal var isCanceled : Bool { return workItem?.isCancelled ?? false}
-//    internal let cancelFlag: AtomicCancel = AtomicCancel()
-//
-//    var onCancel : Canceled?
     internal var cancelBlocks = [DispatchWorkItem]()
 
     public func cancelled(_ onCancel: @escaping Canceled, on queue: DispatchQueue) {
@@ -104,7 +83,7 @@ public class PromiseCancelToken {
             workItem.notify(queue: queue, execute: cancelItem)
         }
     }
-//
+
     public func cancel() {
         if let workItem = workItem {
             workItem.cancel()


### PR DESCRIPTION
The implementation of `AtomicCancel` could not be verified by static or runtime analysis. As an alternative, I've switched the underlying implementation to use [DispatchWorkItem](https://developer.apple.com/documentation/dispatch/dispatchworkitem).

All the tests pass fine, and I added some short dispatch_after delays to make sure that the tests weren't false positives.

In the future, I might be able to replace more code paths with `DispatchWorkItem`. 